### PR TITLE
altering tests to ensure returned item in is correct object format

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -19,10 +19,10 @@ describe("GET /api/topics", () => {
             .get('/api/topics')
             .expect(200)
             .then((response) => {
-                expect(Array.isArray(response.body)).toBe(true)
-                const body = response.body
-                body.forEach((obj) => {
-                    expect(obj === Object(obj)).toBe(true)
+                expect(Array.isArray(response.body.topics)).toBe(true)
+                const topics = response.body.topics
+                topics.forEach((topic) => {
+                    expect(topic === Object(topic)).toBe(true)
                 })
             })
     })
@@ -31,10 +31,10 @@ describe("GET /api/topics", () => {
             .get('/api/topics')
             .expect(200)
             .then((response) => {
-                const body = response.body
-                body.forEach((obj) => {
-                    expect(obj).toHaveProperty('slug')
-                    expect(obj).toHaveProperty('description')
+                const topics = response.body.topics
+                topics.forEach((topic) => {
+                    expect(topic).toHaveProperty('slug')
+                    expect(topic).toHaveProperty('description')
                 })
             })
     })

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -8,7 +8,7 @@ exports.getTopics = ( req, res, next) => {
         :
         selectTopics()
             .then((topics) => {
-                res.status(200).send(topics)
+                res.status(200).send({ topics: topics })
             })
             .catch((err) => {
                 next(err)


### PR DESCRIPTION
previously the GET /api/topics endpoint returned an array of objects.

This PR will ensure the endpoint returns an object, with one key value pair that includes the array of objects.

eg. {topics: [topics array]}